### PR TITLE
Keep template data updated without rerendering.

### DIFF
--- a/lib/registerElement.coffee
+++ b/lib/registerElement.coffee
@@ -33,6 +33,9 @@ Blaze.Template.prototype.registerElement = (name, options) ->
     @childRoot = shadow.querySelector 'div'
     @blazeData = {}
     @blazeView = Blaze.renderWithData blazeTemplate, @blazeData, @childRoot
+    @blazeView.autorun =>
+      _.each @blazeView.dataVar.get(), (name, attr) =>
+        @childRoot.parentNode.host.setAttribute attr, name
   newPrototype.attributeChangedCallback = (name, oldValue, newValue) ->
     @blazeData = @blazeView.dataVar.get()
     @blazeData[name] = newValue

--- a/lib/registerElement.coffee
+++ b/lib/registerElement.coffee
@@ -34,9 +34,9 @@ Blaze.Template.prototype.registerElement = (name, options) ->
     @blazeData = {}
     @blazeView = Blaze.renderWithData blazeTemplate, @blazeData, @childRoot
   newPrototype.attributeChangedCallback = (name, oldValue, newValue) ->
+    @blazeData = @blazeView.dataVar.get()
     @blazeData[name] = newValue
-    Blaze.remove @blazeView
-    @blazeView = Blaze.renderWithData blazeTemplate, @blazeData, @childRoot
+    @blazeView.dataVar.set @blazeData
 
   element = document.registerElement name,
     prototype: newPrototype


### PR DESCRIPTION
Update the data context without removing and rerendering the template.
Also update the attributes on the host tag whenever the data context changes.
